### PR TITLE
fix: harden Recorded Future connector boundaries [Codex]

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -8,13 +8,13 @@ default_stages: [pre-commit]
 # This is a template for connector pre-commit hooks
 repos:
   - repo: https://github.com/compilerla/conventional-pre-commit
-    rev: v4.1.0
+    rev: v4.4.0
     hooks:
       - id: conventional-pre-commit
         stages: [commit-msg]
         args: [--verbose]
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v5.0.0
+    rev: v6.0.0
     hooks:
       - id: check-merge-conflict
       - id: end-of-file-fixer
@@ -27,13 +27,13 @@ repos:
       - id: check-json
       - id: check-yaml
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.11.7
+    rev: v0.15.22
     hooks:
       - id: ruff
         args: [ "--fix", "--unsafe-fixes"] # Allow unsafe fixes (ruff pretty strict about what it can fix)
       - id: ruff-format
   - repo: https://github.com/djlint/djLint
-    rev: v1.36.4
+    rev: v1.40.7
     hooks:
       - id: djlint-reformat-django
       - id: djlint-django
@@ -43,12 +43,12 @@ repos:
       - id: soar-app-linter
         args: ["--single-repo", "--message-level", "error"]
   - repo: https://github.com/hukkin/mdformat
-    rev: 0.7.22
+    rev: 1.0.0
     hooks:
       - id: mdformat
         exclude: "release_notes/.*"
   - repo: https://github.com/returntocorp/semgrep
-    rev: v1.136.0
+    rev: v1.165.0
     hooks:
       - id: semgrep
         additional_dependencies: ["setuptools==81.0.0"]
@@ -61,7 +61,7 @@ repos:
         exclude: "README.md"
   # Central hooks
   - repo: https://github.com/phantomcyber/dev-cicd-tools
-    rev: v2.1.4
+    rev: v2.1.6
     hooks:
       - id: build-docs
         language: python

--- a/recordedfuture_connector.py
+++ b/recordedfuture_connector.py
@@ -789,6 +789,10 @@ class RecordedfutureConnector(BaseConnector):
         return action_result.set_status(phantom.APP_SUCCESS)
 
     def _write_file_to_vault(self, container, file_data, file_name):
+        file_name = os.path.basename(str(file_name).replace("\\", "/"))
+        if file_name in {"", ".", ".."}:
+            raise ValueError("Invalid vault filename")
+
         if hasattr(vault.Vault, "get_vault_tmp_dir"):
             file_path = os.path.join(vault.Vault.get_vault_tmp_dir(), file_name)
         else:

--- a/recordedfuture_connector.py
+++ b/recordedfuture_connector.py
@@ -37,6 +37,7 @@ from datetime import UTC, datetime
 from html import escape
 from math import ceil
 from typing import Literal
+from urllib.parse import quote
 
 # Phantom App imports
 # noinspection PyUnresolvedReferences
@@ -629,11 +630,12 @@ class RecordedfutureConnector(BaseConnector):
         self.save_progress(f"In action handler for: {self.get_action_identifier()}")
         action_result = self.add_action_result(ActionResult(param))
         list_id = UnicodeDammit(param["list_id"]).unicode_markup
-        my_ret_val, response = self._make_rest_call(f"/list/{list_id}/{info_type}", action_result, method="get")
+        safe_list_id = quote(str(list_id), safe="")
+        my_ret_val, response = self._make_rest_call(f"/list/{safe_list_id}/{info_type}", action_result, method="get")
         self.debug_print(
             "_handle_list_details",
             {
-                "endpoint": f"/list/{list_id}/{info_type}",
+                "endpoint": f"/list/{safe_list_id}/{info_type}",
                 "action_result": action_result,
                 "my_ret_val": my_ret_val,
                 "response": response,
@@ -646,6 +648,7 @@ class RecordedfutureConnector(BaseConnector):
         self.save_progress(f"In action handler for: {self.get_action_identifier()}")
         action_result = self.add_action_result(ActionResult(param))
         list_id = UnicodeDammit(param["list_id"]).unicode_markup
+        safe_list_id = quote(str(list_id), safe="")
         entity_id = param.get("entity_id")
         entity_name = param.get("entity_name")
         entity_type = param.get("entity_type")
@@ -655,11 +658,11 @@ class RecordedfutureConnector(BaseConnector):
             "type": (UnicodeDammit(escape(entity_type)).unicode_markup if entity_type else None),
             "id": (UnicodeDammit(escape(entity_id)).unicode_markup if entity_id else None),
         }
-        my_ret_val, response = self._make_rest_call(f"/list/{list_id}/entity/{action}", action_result, json=data, method="post")
+        my_ret_val, response = self._make_rest_call(f"/list/{safe_list_id}/entity/{action}", action_result, json=data, method="post")
         self.debug_print(
             "_handle_manage_list_entities",
             {
-                "endpoint": f"/list/{list_id}/entity/{action}",
+                "endpoint": f"/list/{safe_list_id}/entity/{action}",
                 "action_result": action_result,
                 "my_ret_val": my_ret_val,
                 "response": response,
@@ -1098,6 +1101,7 @@ class RecordedfutureConnector(BaseConnector):
 
         # Required values can be accessed directly
         rule_id = UnicodeDammit(param["rule_id"]).unicode_markup
+        safe_rule_id = quote(str(rule_id), safe="")
         timeframe = UnicodeDammit(param["timeframe"]).unicode_markup
         assert rule_id is not None
         assert timeframe is not None
@@ -1106,12 +1110,12 @@ class RecordedfutureConnector(BaseConnector):
         params = {"triggered": timeframe}
 
         # Make rest call
-        my_ret_val, response = self._make_rest_call(f"/alert/rule/{rule_id}", action_result, params=params)
+        my_ret_val, response = self._make_rest_call(f"/alert/rule/{safe_rule_id}", action_result, params=params)
 
         self.debug_print(
             "_handle_alert_search",
             {
-                "path_info": f"/alert/rule/{rule_id}",
+                "path_info": f"/alert/rule/{safe_rule_id}",
                 "action_result": action_result,
                 "params": params,
                 "my_ret_val": my_ret_val,
@@ -1181,14 +1185,15 @@ class RecordedfutureConnector(BaseConnector):
 
         # Required values can be accessed directly
         alert_id = UnicodeDammit(param["alert_id"]).unicode_markup
+        safe_alert_id = quote(str(alert_id), safe="")
 
         # Make rest call
-        my_ret_val, response = self._make_rest_call(f"/alert/lookup/{alert_id}", action_result)
+        my_ret_val, response = self._make_rest_call(f"/alert/lookup/{safe_alert_id}", action_result)
 
         self.debug_print(
             "_handle_alert_lookup",
             {
-                "path_info": f"/alert/lookup/{alert_id}",
+                "path_info": f"/alert/lookup/{safe_alert_id}",
                 "action_result": action_result,
                 "my_ret_val": my_ret_val,
                 "response": response,
@@ -1359,17 +1364,18 @@ class RecordedfutureConnector(BaseConnector):
         # Add an action result object to self (BaseConnector) to represent
         # the action for this param
         action_result = self.add_action_result(ActionResult(param))
+        safe_alert_id = quote(str(param["alert_id"]), safe="")
 
         # make rest call
         my_ret_val, response = self._make_rest_call(
-            f"/playbook_alert/{param['alert_id']}",
+            f"/playbook_alert/{safe_alert_id}",
             action_result,
         )
 
         self.debug_print(
             "_handle_playbook_alert_details",
             {
-                "path_info": f"/playbook_alert/domain_abuse/{param['alert_id']}",
+                "path_info": f"/playbook_alert/{safe_alert_id}",
                 "action_result": action_result,
                 "my_ret_val": my_ret_val,
                 "response": response,
@@ -1392,6 +1398,7 @@ class RecordedfutureConnector(BaseConnector):
         # Add an action result object to self (BaseConnector) to represent
         # the action for this param
         action_result = self.add_action_result(ActionResult(param))
+        safe_alert_id = quote(str(param["alert_id"]), safe="")
 
         params = {
             "priority": UnicodeDammit(param.get("priority", "")).unicode_markup,
@@ -1402,7 +1409,7 @@ class RecordedfutureConnector(BaseConnector):
 
         # make rest call
         my_ret_val, response = self._make_rest_call(
-            f"/playbook_alert/{param['alert_id']}",
+            f"/playbook_alert/{safe_alert_id}",
             json=params,
             action_result=action_result,
             method="put",
@@ -1411,7 +1418,7 @@ class RecordedfutureConnector(BaseConnector):
         self.debug_print(
             "_handle_playbook_alert_update",
             {
-                "path_info": f"/playbook_alert/{param['alert_id']}",
+                "path_info": f"/playbook_alert/{safe_alert_id}",
                 "action_result": action_result,
                 "my_ret_val": my_ret_val,
                 "response": response,

--- a/release_notes/unreleased.md
+++ b/release_notes/unreleased.md
@@ -1,3 +1,3 @@
 **Unreleased**
 
-* Chore: refresh development checks (temporary baseline note).
+* Restrict detection-rule output to a safe vault filename.

--- a/release_notes/unreleased.md
+++ b/release_notes/unreleased.md
@@ -1,3 +1,4 @@
 **Unreleased**
 
 * Restrict detection-rule output to a safe vault filename.
+* Encode Recorded Future identifiers before inserting them into API paths.

--- a/release_notes/unreleased.md
+++ b/release_notes/unreleased.md
@@ -2,3 +2,4 @@
 
 * Restrict detection-rule output to a safe vault filename.
 * Encode Recorded Future identifiers before inserting them into API paths.
+* Escape Recorded Future widget values before inserting them into JavaScript contexts.

--- a/release_notes/unreleased.md
+++ b/release_notes/unreleased.md
@@ -3,3 +3,4 @@
 * Restrict detection-rule output to a safe vault filename.
 * Encode Recorded Future identifiers before inserting them into API paths.
 * Escape Recorded Future widget values before inserting them into JavaScript contexts.
+* Restrict threat-intelligence portal links to HTTPS URLs.

--- a/release_notes/unreleased.md
+++ b/release_notes/unreleased.md
@@ -1,1 +1,3 @@
 **Unreleased**
+
+* Chore: refresh development checks (temporary baseline note).

--- a/views/alert_lookup_results.html
+++ b/views/alert_lookup_results.html
@@ -207,7 +207,7 @@ and will be merged during compilation:
                   <br />
                   {{ alert.title }}
                   (<a href="javascript:;"
-   onclick="context_menu(this, [{'contains': ['recordedfuture alert id'], 'value': '{{ alert.id }}' }], 0, {{ container.id }}, null, false);">
+   onclick="context_menu(this, [{'contains': ['recordedfuture alert id'], 'value': '{{ alert.id|escapejs }}' }], 0, {{ container.id }}, null, false);">
                   <span class="highlighted">{{ alert.id }})</span>&nbsp;<span class="fa fa-caret-down" style="font-size: smaller;"></span>
                 </a>
               </td>
@@ -239,7 +239,7 @@ and will be merged during compilation:
                 <br />
                 {{ alert.rule.name }}
                 (<a href="javascript:;"
-   onclick="context_menu(this, [{'contains': ['recordedfuture alert rule id'], 'value': '{{ alert.rule.id }}' }], 0, {{ container.id }}, null, false);">
+   onclick="context_menu(this, [{'contains': ['recordedfuture alert rule id'], 'value': '{{ alert.rule.id|escapejs }}' }], 0, {{ container.id }}, null, false);">
                 <span class="highlighted">{{ alert.rule.id }})</span>&nbsp;<span class="fa fa-caret-down" style="font-size: smaller;"></span>
               </td>
             </tr>
@@ -301,7 +301,7 @@ and will be merged during compilation:
                     <td>
                       <span class="non-highlighted">Entity</span>:
                       <a href="javascript:;"
-                         onclick="context_menu(this, [{'contains': ['{{ entity_type }}'], 'value': '{{ entity.entity }}' }], 0, {{ container.id }}, null, false);">
+                         onclick="context_menu(this, [{'contains': ['{{ entity_type|escapejs }}'], 'value': '{{ entity.entity|escapejs }}' }], 0, {{ container.id }}, null, false);">
                         <span class="highlighted">{{ entity.entity }}</span>&nbsp;<span class="fa fa-caret-down" style="font-size: smaller;"></span></a>
                       <br />
                       <span class="non-highlighted">Source</span>: {{ entity.source }}

--- a/views/alert_rule_search_results.html
+++ b/views/alert_rule_search_results.html
@@ -205,7 +205,7 @@ and will be merged during compilation:
                   <span class="non-highlighted">Rule Id</span>
                   <br />
                   <a href="javascript:;"
-                     onclick="context_menu(this, [{'contains': ['recordedfuture alert rule id'], 'value': '{{ rule.id }}' }], 0, {{ container.id }}, null, false);">
+                     onclick="context_menu(this, [{'contains': ['recordedfuture alert rule id'], 'value': '{{ rule.id|escapejs }}' }], 0, {{ container.id }}, null, false);">
                     <span class="highlighted">{{ rule.id }}</span>&nbsp;<span class="fa fa-caret-down" style="font-size: smaller;"></span>
                   </td>
                   <td>

--- a/views/alert_search_results.html
+++ b/views/alert_search_results.html
@@ -207,7 +207,7 @@ and will be merged during compilation:
                   <br />
                   {{ alert.rule.name }}
                   (<a href="javascript:;"
-   onclick="context_menu(this, [{'contains': ['recordedfuture alert rule id'], 'value': '{{ alert.rule.id }}' }], 0, {{ container.id }}, null, false);">
+   onclick="context_menu(this, [{'contains': ['recordedfuture alert rule id'], 'value': '{{ alert.rule.id|escapejs }}' }], 0, {{ container.id }}, null, false);">
                   <span class="highlighted">{{ alert.rule.id }})</span>&nbsp;<span class="fa fa-caret-down" style="font-size: smaller;"></span></a>
               </td>
               <td style="width: 20%">
@@ -223,7 +223,7 @@ and will be merged during compilation:
                   <br />
                   {{ triggered.title }}
                   (<a href="javascript:;"
-   onclick="context_menu(this, [{'contains': ['recordedfuture alert id'], 'value': '{{ triggered.id }}' }], 0, {{ container.id }}, null, false);">
+   onclick="context_menu(this, [{'contains': ['recordedfuture alert id'], 'value': '{{ triggered.id|escapejs }}' }], 0, {{ container.id }}, null, false);">
                   <span class="highlighted">{{ triggered.id }})</span>&nbsp;<span class="fa fa-caret-down" style="font-size: smaller;"></span></a>
               </td>
               <td>

--- a/views/alert_update_results.html
+++ b/views/alert_update_results.html
@@ -207,7 +207,7 @@ and will be merged during compilation:
                 <br />
                 {{ alert_update.title }}
                 (<a href="javascript:;"
-   onclick="context_menu(this, [{'contains': ['recordedfuture alert id'], 'value': '{{ result.param.alert_id }}' }], 0, {{ container.id }}, null, false);">
+   onclick="context_menu(this, [{'contains': ['recordedfuture alert id'], 'value': '{{ result.param.alert_id|escapejs }}' }], 0, {{ container.id }}, null, false);">
                 <span class="highlighted">{{ result.param.alert_id }})</span>&nbsp;<span class="fa fa-caret-down" style="font-size: smaller;"></span>
               </a>
             </td>

--- a/views/intelligence_results.html
+++ b/views/intelligence_results.html
@@ -206,301 +206,301 @@ and will be merged during compilation:
                 {% if result.param.ip %}
                   <span class="non-highlighted">IP Intelligence</span>
                   <br>
-                <a href="javascript:;"
-                   onclick="context_menu(this, [{'contains': ['ip'], 'value': '{{ result.param.ip }}' }], 0, {{ container.id }}, null, false);"><span class="highlighted">{{ result.param.ip }}</span>&nbsp;<span class="fa fa-caret-down" style="font-size: smaller;"></span>
-              </a>
+                  <a href="javascript:;"
+                     onclick="context_menu(this, [{'contains': ['ip'], 'value': '{{ result.param.ip }}' }], 0, {{ container.id }}, null, false);"><span class="highlighted">{{ result.param.ip }}</span>&nbsp;<span class="fa fa-caret-down" style="font-size: smaller;"></span>
+                  </a>
+                {% endif %}
+                {% if result.param.domain %}
+                  <span class="non-highlighted">Domain Intelligence</span>
+                  <br>
+                  <a href="javascript:;"
+                     onclick="context_menu(this, [{'contains': ['domain'], 'value': '{{ result.param.domain }}' }], 0, {{ container.id }}, null, false);"><span class="highlighted">{{ result.param.domain }}</span>&nbsp;<span class="fa fa-caret-down" style="font-size: smaller;"></span>
+                  </a>
+                {% endif %}
+                {% if result.param.hash %}
+                  <span class="non-highlighted">File Intelligence</span>
+                  <br>
+                  <a href="javascript:;"
+                     onclick="context_menu(this, [{'contains': ['file'], 'value': '{{ result.param.hash }}' }], 0, {{ container.id }}, null, false);"><span class="highlighted">{{ result.param.hash }}</span>&nbsp;<span class="fa fa-caret-down" style="font-size: smaller;"></span>
+                  </a>
+                {% endif %}
+                {% if result.param.url %}
+                  <span class="non-highlighted">URL Intelligence</span>
+                  <br>
+                  <a href="javascript:;"
+                     onclick="context_menu(this, [{'contains': ['url'], 'value': '{{ result.param.url }}' }], 0, {{ container.id }}, null, false);"><span class="highlighted">{{ result.param.url }}</span>&nbsp;<span class="fa fa-caret-down" style="font-size: smaller;"></span>
+                  </a>
+                {% endif %}
+                {% if result.param.vulnerability %}
+                  <span class="non-highlighted">Vulnerability Intelligence</span>
+                  <br>
+                  <a href="javascript:;"
+                     onclick="context_menu(this, [{'contains': ['cve','recordedfuture vulnerability id','vulnerability'], 'value': '{{ result.param.vulnerability }}' }], 0, {{ container.id }}, null, false);"><span class="highlighted">{{ result.param.vulnerability }}</span>&nbsp;<span class="fa fa-caret-down" style="font-size: smaller;"></span>
+                  </a>
+                {% endif %}
+              </td>
+            </tr>
+            <tr>
+              <td>
+                <span class="non-highlighted">Risk Score</span>
+                <br />
+                {{ result.data.risk.score }}
+              </td>
+              <td>
+                <span class="non-highlighted">Risk Rules Triggered</span>
+                <br />
+                {{ result.data.risk.riskSummary }}
+              </td>
+              <td class="rf-timestamp">
+                <span class="non-highlighted">First Seen</span>
+                <br />
+                <span title="{{ result.data.timestamps.firstSeen }}">{{ result.data.timestamps.firstSeenShort }}</span>
+              </td>
+              <td class="rf-timestamp">
+                <span class="non-highlighted">Last Seen</span>
+                <br />
+                <span title="{{ result.data.timestamps.lastSeen }}">{{ result.data.timestamps.lastSeenShort }}</span>
+              </td>
+              <td>
+                <span class="non-highlighted">Intelligence Card</span>
+                <br />
+                {% if result.data.intelCard %}
+                  <a href="{{ result.data.intelCard }}" target="new">Open</a>
+                {% elif result.intelCard %}
+                  <a href="{{ result.intelCard }}" target="new">Open</a>
+                {% endif %}
+              </td>
+            </tr>
+            {% if result.data.mitreTags %}
+              <tr>
+                <td colspan="5">
+                  <span class="non-highlighted">MITRE ATT&CK</span>
+                  <br>
+                  {{ result.data.mitreTags }}
+                </td>
+              </tr>
             {% endif %}
-            {% if result.param.domain %}
-              <span class="non-highlighted">Domain Intelligence</span>
-              <br>
-            <a href="javascript:;"
-               onclick="context_menu(this, [{'contains': ['domain'], 'value': '{{ result.param.domain }}' }], 0, {{ container.id }}, null, false);"><span class="highlighted">{{ result.param.domain }}</span>&nbsp;<span class="fa fa-caret-down" style="font-size: smaller;"></span>
-          </a>
+            {% if result.data.ai_insights %}
+              <tr>
+                <td colspan="5">
+                  <span class="non-highlighted">Recorded Future AI Insights</span>
+                  <br>
+                  {{ result.data.ai_insights }}
+                </td>
+              </tr>
+            {% endif %}
+          </table>
+        </div>
+        <!-- NVD CVSS -->
+        {% if result.data.nvdDescription %}
+          <div class="rf-box">
+            <table class="rf-table">
+              <tr>
+                <td>
+                  <span class="non-highlighted">NVD Vulnerability Description</span>
+                  <br />
+                  {{ result.data.nvdDescription }}
+                </td>
+              </tr>
+            </table>
+          </div>
         {% endif %}
-        {% if result.param.hash %}
-          <span class="non-highlighted">File Intelligence</span>
-          <br>
-        <a href="javascript:;"
-           onclick="context_menu(this, [{'contains': ['file'], 'value': '{{ result.param.hash }}' }], 0, {{ container.id }}, null, false);"><span class="highlighted">{{ result.param.hash }}</span>&nbsp;<span class="fa fa-caret-down" style="font-size: smaller;"></span>
-      </a>
-    {% endif %}
-    {% if result.param.url %}
-      <span class="non-highlighted">URL Intelligence</span>
-      <br>
-    <a href="javascript:;"
-       onclick="context_menu(this, [{'contains': ['url'], 'value': '{{ result.param.url }}' }], 0, {{ container.id }}, null, false);"><span class="highlighted">{{ result.param.url }}</span>&nbsp;<span class="fa fa-caret-down" style="font-size: smaller;"></span>
-  </a>
-{% endif %}
-{% if result.param.vulnerability %}
-  <span class="non-highlighted">Vulnerability Intelligence</span>
-  <br>
-<a href="javascript:;"
-   onclick="context_menu(this, [{'contains': ['cve','recordedfuture vulnerability id','vulnerability'], 'value': '{{ result.param.vulnerability }}' }], 0, {{ container.id }}, null, false);"><span class="highlighted">{{ result.param.vulnerability }}</span>&nbsp;<span class="fa fa-caret-down" style="font-size: smaller;"></span>
-</a>
-{% endif %}
-</td>
-</tr>
-<tr>
-  <td>
-    <span class="non-highlighted">Risk Score</span>
-    <br />
-    {{ result.data.risk.score }}
-  </td>
-  <td>
-    <span class="non-highlighted">Risk Rules Triggered</span>
-    <br />
-    {{ result.data.risk.riskSummary }}
-  </td>
-  <td class="rf-timestamp">
-    <span class="non-highlighted">First Seen</span>
-    <br />
-    <span title="{{ result.data.timestamps.firstSeen }}">{{ result.data.timestamps.firstSeenShort }}</span>
-  </td>
-  <td class="rf-timestamp">
-    <span class="non-highlighted">Last Seen</span>
-    <br />
-    <span title="{{ result.data.timestamps.lastSeen }}">{{ result.data.timestamps.lastSeenShort }}</span>
-  </td>
-  <td>
-    <span class="non-highlighted">Intelligence Card</span>
-    <br />
-    {% if result.data.intelCard %}
-      <a href="{{ result.data.intelCard }}" target="new">Open</a>
-    {% elif result.intelCard %}
-      <a href="{{ result.intelCard }}" target="new">Open</a>
-    {% endif %}
-  </td>
-</tr>
-{% if result.data.mitreTags %}
-  <tr>
-    <td colspan="5">
-      <span class="non-highlighted">MITRE ATT&CK</span>
-      <br>
-      {{ result.data.mitreTags }}
-    </td>
-  </tr>
-{% endif %}
-{% if result.data.ai_insights %}
-  <tr>
-    <td colspan="5">
-      <span class="non-highlighted">Recorded Future AI Insights</span>
-      <br>
-      {{ result.data.ai_insights }}
-    </td>
-  </tr>
-{% endif %}
-</table>
-</div>
-<!-- NVD CVSS -->
-{% if result.data.nvdDescription %}
-  <div class="rf-box">
-    <table class="rf-table">
-      <tr>
-        <td>
-          <span class="non-highlighted">NVD Vulnerability Description</span>
-          <br />
-          {{ result.data.nvdDescription }}
-        </td>
-      </tr>
-    </table>
+        <!-- Risk Rules Triggered -->
+        {% if result.data.risk.evidenceDetails %}
+          <div class="rf-box">
+            <table class="rf-table">
+              <tr>
+                <td colspan="4">Triggered Risk Rules</td>
+              </tr>
+              {% for rule in result.data.risk.evidenceDetails|dictsortreversed:"criticality" %}
+                <tr>
+                  <td class="rf-criticality-level-{{ rule.criticality }}"></td>
+                  <td>
+                    <span class="non-highlighted">Risk Rule</span>
+                    <br />
+                    {{ rule.rule }}
+                  </td>
+                  <td>
+                    <span class="non-highlighted">Evidence</span>
+                    <br />
+                    {{ rule.evidenceString }}
+                  </td>
+                  <td class="rf-timestamp">
+                    <span class="non-highlighted">Timestamp</span>
+                    <br />
+                    <span title="{{ rule.timestamp }}">{{ rule.timestampShort }}</span>
+                  </td>
+                </tr>
+              {% endfor %}
+            </table>
+          </div>
+        {% endif %}
+        <!-- NVD CVSS -->
+        {% if result.data.cvss %}
+          <div class="rf-box">
+            <table class="rf-table">
+              <tr>
+                <td colspan="9">CVSS Vulnerability Metrics</td>
+              </tr>
+              <tr>
+                <td>
+                  <span class="non-highlighted">Access Vector</span>
+                  <br />
+                  {{ result.data.cvss.accessVector }}
+                </td>
+                <td>
+                  <span class="non-highlighted">Availability</span>
+                  <br />
+                  {{ result.data.cvss.availability }}
+                </td>
+                <td>
+                  <span class="non-highlighted">Score</span>
+                  <br />
+                  {{ result.data.cvss.score }}
+                </td>
+                <td>
+                  <span class="non-highlighted">Access Complexity</span>
+                  <br />
+                  {{ result.data.cvss.accessComplexity }}
+                </td>
+                <td>
+                  <span class="non-highlighted">Authentication</span>
+                  <br />
+                  {{ result.data.cvss.authentication }}
+                </td>
+                <td>
+                  <span class="non-highlighted">Confidentiality</span>
+                  <br />
+                  {{ result.data.cvss.confidentiality }}
+                </td>
+                <td>
+                  <span class="non-highlighted">Integrity</span>
+                  <br />
+                  {{ result.data.cvss.integrity }}
+                </td>
+                <td>
+                  <span class="non-highlighted">Published</span>
+                  <br />
+                  <span title="{{ result.data.cvss.published }}">{{ result.data.cvss.publishedShort }}</span>
+                </td>
+                <td>
+                  <span class="non-highlighted">Last Modified</span>
+                  <br />
+                  <span title="{{ result.data.cvss.lastModified }}">{{ result.data.cvss.lastModifiedShort }}</span>
+                </td>
+              </tr>
+            </table>
+          </div>
+        {% endif %}
+        <!-- Threat Lists -->
+        {% if result.data.threatLists %}
+          <div class="rf-box">
+            <table class="rf-table">
+              <tr>
+                <td colspan="2">Threat Lists</td>
+              </tr>
+              {% for threatList in result.data.threatLists %}
+                <tr>
+                  <td style="min-width: 20ex;">
+                    <span class="non-highlighted">Threatlist Name</span>
+                    <br />
+                    {{ threatList.name }}
+                  </td>
+                  <td>
+                    <span class="non-highlighted">Description</span>
+                    <br />
+                    {{ threatList.description }}
+                  </td>
+                </tr>
+              {% endfor %}
+            </table>
+          </div>
+        {% endif %}
+        <!-- Location -->
+        {% if result.data.location %}
+          <div class="rf-box">
+            <table class="rf-table">
+              <tr>
+                <td colspan="5">ASN and Geolocation</td>
+              </tr>
+              <tr>
+                <td>
+                  <span class="non-highlighted">AS Number</span>
+                  <br />
+                  {{ result.data.location.asn }}
+                </td>
+                <td>
+                  <span class="non-highlighted">AS Name</span>
+                  <br />
+                  {{ result.data.location.organization }}
+                </td>
+                <td>
+                  <span class="non-highlighted">IP Range</span>
+                  <br />
+                  {{ result.data.location.cidr.name }}
+                </td>
+                <td>
+                  <span class="non-highlighted">Geolocation (city)</span>
+                  <br />
+                  {{ result.data.location.location.city }}
+                </td>
+                <td>
+                  <span class="non-highlighted">Geolocation (country)</span>
+                  <br />
+                  {{ result.data.location.location.country }}
+                </td>
+              </tr>
+            </table>
+          </div>
+        {% endif %}
+        {% if result.data.recordedfutureLinks %}
+          <div class="rf-box">
+            <table class="rf-table">
+              <tr>
+                <td>Recorded Future Research and Technical Links</td>
+              </tr>
+              {% for entity_type, entities in result.data.recordedfutureLinks.entities.items %}
+                <tr>
+                  <td>
+                    <strong>{{ entity_type|upper }}</strong>
+                    <br>
+                    {% for entity in entities|dictsortreversed:"score" %}
+                      {% if entity_type == 'other' %}
+                        {{ entity.type|title }} :  {{ entity.name }}
+                        <br>
+                      {% else %}
+                        Risk: {{ entity.score }}&nbsp;&nbsp; |&nbsp;&nbsp;
+                        <a href="javascript:;"
+                           onclick="context_menu(this, [{'contains': ['{{ entity_type }}'], 'value': '{{ entity.name }}' }], 0, {{ container.id }}, null, false);">
+                          {{ entity.name }}
+                          <span class="fa fa-caret-down" style="font-size: smaller;"></span>
+                        </a>
+                        <br>
+                      {% endif %}
+                    {% endfor %}
+                  </td>
+                </tr>
+              {% endfor %}
+            </table>
+          </div>
+        {% endif %}
+      {% else %}
+        <!-- handle no data responses -->
+        <table class="rf-table">
+          <tr>
+            <th>Status</th>
+            <th>Message</th>
+          </tr>
+          <tr>
+            <td>{{ result.status }}</td>
+            <td>{{ result.message }}</td>
+          </tr>
+        </table>
+      {% endif %}
+      <!------------------- For each Result END ---------------------->
+    {% endfor %}
+    <!-- loop for each result end -->
   </div>
-{% endif %}
-<!-- Risk Rules Triggered -->
-{% if result.data.risk.evidenceDetails %}
-  <div class="rf-box">
-    <table class="rf-table">
-      <tr>
-        <td colspan="4">Triggered Risk Rules</td>
-      </tr>
-      {% for rule in result.data.risk.evidenceDetails|dictsortreversed:"criticality" %}
-        <tr>
-          <td class="rf-criticality-level-{{ rule.criticality }}"></td>
-          <td>
-            <span class="non-highlighted">Risk Rule</span>
-            <br />
-            {{ rule.rule }}
-          </td>
-          <td>
-            <span class="non-highlighted">Evidence</span>
-            <br />
-            {{ rule.evidenceString }}
-          </td>
-          <td class="rf-timestamp">
-            <span class="non-highlighted">Timestamp</span>
-            <br />
-            <span title="{{ rule.timestamp }}">{{ rule.timestampShort }}</span>
-          </td>
-        </tr>
-      {% endfor %}
-    </table>
-  </div>
-{% endif %}
-<!-- NVD CVSS -->
-{% if result.data.cvss %}
-  <div class="rf-box">
-    <table class="rf-table">
-      <tr>
-        <td colspan="9">CVSS Vulnerability Metrics</td>
-      </tr>
-      <tr>
-        <td>
-          <span class="non-highlighted">Access Vector</span>
-          <br />
-          {{ result.data.cvss.accessVector }}
-        </td>
-        <td>
-          <span class="non-highlighted">Availability</span>
-          <br />
-          {{ result.data.cvss.availability }}
-        </td>
-        <td>
-          <span class="non-highlighted">Score</span>
-          <br />
-          {{ result.data.cvss.score }}
-        </td>
-        <td>
-          <span class="non-highlighted">Access Complexity</span>
-          <br />
-          {{ result.data.cvss.accessComplexity }}
-        </td>
-        <td>
-          <span class="non-highlighted">Authentication</span>
-          <br />
-          {{ result.data.cvss.authentication }}
-        </td>
-        <td>
-          <span class="non-highlighted">Confidentiality</span>
-          <br />
-          {{ result.data.cvss.confidentiality }}
-        </td>
-        <td>
-          <span class="non-highlighted">Integrity</span>
-          <br />
-          {{ result.data.cvss.integrity }}
-        </td>
-        <td>
-          <span class="non-highlighted">Published</span>
-          <br />
-          <span title="{{ result.data.cvss.published }}">{{ result.data.cvss.publishedShort }}</span>
-        </td>
-        <td>
-          <span class="non-highlighted">Last Modified</span>
-          <br />
-          <span title="{{ result.data.cvss.lastModified }}">{{ result.data.cvss.lastModifiedShort }}</span>
-        </td>
-      </tr>
-    </table>
-  </div>
-{% endif %}
-<!-- Threat Lists -->
-{% if result.data.threatLists %}
-  <div class="rf-box">
-    <table class="rf-table">
-      <tr>
-        <td colspan="2">Threat Lists</td>
-      </tr>
-      {% for threatList in result.data.threatLists %}
-        <tr>
-          <td style="min-width: 20ex;">
-            <span class="non-highlighted">Threatlist Name</span>
-            <br />
-            {{ threatList.name }}
-          </td>
-          <td>
-            <span class="non-highlighted">Description</span>
-            <br />
-            {{ threatList.description }}
-          </td>
-        </tr>
-      {% endfor %}
-    </table>
-  </div>
-{% endif %}
-<!-- Location -->
-{% if result.data.location %}
-  <div class="rf-box">
-    <table class="rf-table">
-      <tr>
-        <td colspan="5">ASN and Geolocation</td>
-      </tr>
-      <tr>
-        <td>
-          <span class="non-highlighted">AS Number</span>
-          <br />
-          {{ result.data.location.asn }}
-        </td>
-        <td>
-          <span class="non-highlighted">AS Name</span>
-          <br />
-          {{ result.data.location.organization }}
-        </td>
-        <td>
-          <span class="non-highlighted">IP Range</span>
-          <br />
-          {{ result.data.location.cidr.name }}
-        </td>
-        <td>
-          <span class="non-highlighted">Geolocation (city)</span>
-          <br />
-          {{ result.data.location.location.city }}
-        </td>
-        <td>
-          <span class="non-highlighted">Geolocation (country)</span>
-          <br />
-          {{ result.data.location.location.country }}
-        </td>
-      </tr>
-    </table>
-  </div>
-{% endif %}
-{% if result.data.recordedfutureLinks %}
-  <div class="rf-box">
-    <table class="rf-table">
-      <tr>
-        <td>Recorded Future Research and Technical Links</td>
-      </tr>
-      {% for entity_type, entities in result.data.recordedfutureLinks.entities.items %}
-        <tr>
-          <td>
-            <strong>{{ entity_type|upper }}</strong>
-            <br>
-            {% for entity in entities|dictsortreversed:"score" %}
-              {% if entity_type == 'other' %}
-                {{ entity.type|title }} :  {{ entity.name }}
-                <br>
-              {% else %}
-                Risk: {{ entity.score }}&nbsp;&nbsp; |&nbsp;&nbsp;
-                <a href="javascript:;"
-                   onclick="context_menu(this, [{'contains': ['{{ entity_type }}'], 'value': '{{ entity.name }}' }], 0, {{ container.id }}, null, false);">
-                  {{ entity.name }}
-                  <span class="fa fa-caret-down" style="font-size: smaller;"></span>
-                </a>
-                <br>
-              {% endif %}
-            {% endfor %}
-          </td>
-        </tr>
-      {% endfor %}
-    </table>
-  </div>
-{% endif %}
-{% else %}
-<!-- handle no data responses -->
-<table class="rf-table">
-  <tr>
-    <th>Status</th>
-    <th>Message</th>
-  </tr>
-  <tr>
-    <td>{{ result.status }}</td>
-    <td>{{ result.message }}</td>
-  </tr>
-</table>
-{% endif %}
-<!------------------- For each Result END ---------------------->
-{% endfor %}
-<!-- loop for each result end -->
-</div>
-<!-- Main Div -->
+  <!-- Main Div -->
 {% endblock %}
 <!-- Main Start Block -->

--- a/views/intelligence_results.html
+++ b/views/intelligence_results.html
@@ -207,35 +207,35 @@ and will be merged during compilation:
                   <span class="non-highlighted">IP Intelligence</span>
                   <br>
                   <a href="javascript:;"
-                     onclick="context_menu(this, [{'contains': ['ip'], 'value': '{{ result.param.ip }}' }], 0, {{ container.id }}, null, false);"><span class="highlighted">{{ result.param.ip }}</span>&nbsp;<span class="fa fa-caret-down" style="font-size: smaller;"></span>
+                     onclick="context_menu(this, [{'contains': ['ip'], 'value': '{{ result.param.ip|escapejs }}' }], 0, {{ container.id }}, null, false);"><span class="highlighted">{{ result.param.ip }}</span>&nbsp;<span class="fa fa-caret-down" style="font-size: smaller;"></span>
                   </a>
                 {% endif %}
                 {% if result.param.domain %}
                   <span class="non-highlighted">Domain Intelligence</span>
                   <br>
                   <a href="javascript:;"
-                     onclick="context_menu(this, [{'contains': ['domain'], 'value': '{{ result.param.domain }}' }], 0, {{ container.id }}, null, false);"><span class="highlighted">{{ result.param.domain }}</span>&nbsp;<span class="fa fa-caret-down" style="font-size: smaller;"></span>
+                     onclick="context_menu(this, [{'contains': ['domain'], 'value': '{{ result.param.domain|escapejs }}' }], 0, {{ container.id }}, null, false);"><span class="highlighted">{{ result.param.domain }}</span>&nbsp;<span class="fa fa-caret-down" style="font-size: smaller;"></span>
                   </a>
                 {% endif %}
                 {% if result.param.hash %}
                   <span class="non-highlighted">File Intelligence</span>
                   <br>
                   <a href="javascript:;"
-                     onclick="context_menu(this, [{'contains': ['file'], 'value': '{{ result.param.hash }}' }], 0, {{ container.id }}, null, false);"><span class="highlighted">{{ result.param.hash }}</span>&nbsp;<span class="fa fa-caret-down" style="font-size: smaller;"></span>
+                     onclick="context_menu(this, [{'contains': ['file'], 'value': '{{ result.param.hash|escapejs }}' }], 0, {{ container.id }}, null, false);"><span class="highlighted">{{ result.param.hash }}</span>&nbsp;<span class="fa fa-caret-down" style="font-size: smaller;"></span>
                   </a>
                 {% endif %}
                 {% if result.param.url %}
                   <span class="non-highlighted">URL Intelligence</span>
                   <br>
                   <a href="javascript:;"
-                     onclick="context_menu(this, [{'contains': ['url'], 'value': '{{ result.param.url }}' }], 0, {{ container.id }}, null, false);"><span class="highlighted">{{ result.param.url }}</span>&nbsp;<span class="fa fa-caret-down" style="font-size: smaller;"></span>
+                     onclick="context_menu(this, [{'contains': ['url'], 'value': '{{ result.param.url|escapejs }}' }], 0, {{ container.id }}, null, false);"><span class="highlighted">{{ result.param.url }}</span>&nbsp;<span class="fa fa-caret-down" style="font-size: smaller;"></span>
                   </a>
                 {% endif %}
                 {% if result.param.vulnerability %}
                   <span class="non-highlighted">Vulnerability Intelligence</span>
                   <br>
                   <a href="javascript:;"
-                     onclick="context_menu(this, [{'contains': ['cve','recordedfuture vulnerability id','vulnerability'], 'value': '{{ result.param.vulnerability }}' }], 0, {{ container.id }}, null, false);"><span class="highlighted">{{ result.param.vulnerability }}</span>&nbsp;<span class="fa fa-caret-down" style="font-size: smaller;"></span>
+                     onclick="context_menu(this, [{'contains': ['cve','recordedfuture vulnerability id','vulnerability'], 'value': '{{ result.param.vulnerability|escapejs }}' }], 0, {{ container.id }}, null, false);"><span class="highlighted">{{ result.param.vulnerability }}</span>&nbsp;<span class="fa fa-caret-down" style="font-size: smaller;"></span>
                   </a>
                 {% endif %}
               </td>
@@ -471,7 +471,7 @@ and will be merged during compilation:
                       {% else %}
                         Risk: {{ entity.score }}&nbsp;&nbsp; |&nbsp;&nbsp;
                         <a href="javascript:;"
-                           onclick="context_menu(this, [{'contains': ['{{ entity_type }}'], 'value': '{{ entity.name }}' }], 0, {{ container.id }}, null, false);">
+                           onclick="context_menu(this, [{'contains': ['{{ entity_type|escapejs }}'], 'value': '{{ entity.name|escapejs }}' }], 0, {{ container.id }}, null, false);">
                           {{ entity.name }}
                           <span class="fa fa-caret-down" style="font-size: smaller;"></span>
                         </a>

--- a/views/reputation_results.html
+++ b/views/reputation_results.html
@@ -207,27 +207,27 @@ and will be merged during compilation:
                   <span class="non-highlighted">Domain Reputation</span>
                   <br />
                   <a href="javascript:;"
-                     onclick="context_menu(this, [{'contains': ['domain'], 'value': '{{ result.param.domain }}' }], 0, {{ container.id }}, null, false);">{{ result.param.domain }}&nbsp;<span class="fa fa-caret-down" style="font-size: smaller;"></span></a>
+                     onclick="context_menu(this, [{'contains': ['domain'], 'value': '{{ result.param.domain|escapejs }}' }], 0, {{ container.id }}, null, false);">{{ result.param.domain }}&nbsp;<span class="fa fa-caret-down" style="font-size: smaller;"></span></a>
                 {% elif result.param.ip %}
                   <span class="non-highlighted">IP Reputation</span>
                   <br />
                   <a href="javascript:;"
-                     onclick="context_menu(this, [{'contains': ['ip'], 'value': '{{ result.param.ip }}' }], 0, {{ container.id }}, null, false);">{{ result.param.ip }}&nbsp;<span class="fa fa-caret-down" style="font-size: smaller;"></span></a>
+                     onclick="context_menu(this, [{'contains': ['ip'], 'value': '{{ result.param.ip|escapejs }}' }], 0, {{ container.id }}, null, false);">{{ result.param.ip }}&nbsp;<span class="fa fa-caret-down" style="font-size: smaller;"></span></a>
                 {% elif result.param.hash %}
                   <span class="non-highlighted">Hash Reputation</span>
                   <br />
                   <a href="javascript:;"
-                     onclick="context_menu(this, [{'contains': ['hash'], 'value': '{{ result.param.hash }}' }], 0, {{ container.id }}, null, false);">{{ result.param.hash }}&nbsp;<span class="fa fa-caret-down" style="font-size: smaller;"></span></a>
+                     onclick="context_menu(this, [{'contains': ['hash'], 'value': '{{ result.param.hash|escapejs }}' }], 0, {{ container.id }}, null, false);">{{ result.param.hash }}&nbsp;<span class="fa fa-caret-down" style="font-size: smaller;"></span></a>
                 {% elif result.param.url %}
                   <span class="non-highlighted">URL Reputation</span>
                   <br />
                   <a href="javascript:;"
-                     onclick="context_menu(this, [{'contains': ['url'], 'value': '{{ result.param.url }}' }], 0, {{ container.id }}, null, false);">{{ result.param.url }}&nbsp;<span class="fa fa-caret-down" style="font-size: smaller;"></span></a>
+                     onclick="context_menu(this, [{'contains': ['url'], 'value': '{{ result.param.url|escapejs }}' }], 0, {{ container.id }}, null, false);">{{ result.param.url }}&nbsp;<span class="fa fa-caret-down" style="font-size: smaller;"></span></a>
                 {% elif result.param.vulnerability %}
                   <span class="non-highlighted">Vulnerability Reputation</span>
                   <br />
                   <a href="javascript:;"
-                     onclick="context_menu(this, [{'contains': ['vulnerability'], 'value': '{{ result.param.vulnerability }}' }], 0, {{ container.id }}, null, false);">{{ result.param.vulnerability }}&nbsp;<span class="fa fa-caret-down" style="font-size: smaller;"></span></a>
+                     onclick="context_menu(this, [{'contains': ['vulnerability'], 'value': '{{ result.param.vulnerability|escapejs }}' }], 0, {{ container.id }}, null, false);">{{ result.param.vulnerability }}&nbsp;<span class="fa fa-caret-down" style="font-size: smaller;"></span></a>
                 {% endif %}
               </td>
             </tr>

--- a/views/threat_actor_intelligence_results.html
+++ b/views/threat_actor_intelligence_results.html
@@ -203,7 +203,11 @@ and will be merged during compilation:
       <h5>Actor Opportunity: {{ result.data.opportunity|default:"N/A" }}</h5>
       <h5>Actor Severity: {{ result.data.severity|default:"N/A" }}</h5>
       <h5>Actor Categories: {{ result.data.categories|join:", "|default:"N/A" }}</h5>
-      <a href="{{ result.data.intelCard }}">Link to Portal</a>
+      {% if result.data.intelCard|slice:":8" == "https://" %}
+        <a href="{{ result.data.intelCard }}">Link to Portal</a>
+      {% else %}
+        <span>Portal link unavailable</span>
+      {% endif %}
       <h4>Links for {{ result.data.name }} :</h4>
       <div class="rf-full-width-box">
         <table class="rf-table">

--- a/views/threat_map_results.html
+++ b/views/threat_map_results.html
@@ -205,7 +205,11 @@ and will be merged during compilation:
         <h5>Opportunity: {{ actor.opportunity }}</h5>
         <h5>Severity: {{ actor.severity }}</h5>
         <h5>Categories: {{ actor.categories|join:", "|default:"N/A" }}</h5>
-        <a href="{{ actor.intelCard }}">Link to Portal</a>
+        {% if actor.intelCard|slice:":8" == "https://" %}
+          <a href="{{ actor.intelCard }}">Link to Portal</a>
+        {% else %}
+          <span>Portal link unavailable</span>
+        {% endif %}
         <br />
         <hr />
       {% endfor %}


### PR DESCRIPTION
### Bug Fixes

- Restrict detection-rule output to safe vault leaf filenames (PSAAS-30839).
- Encode list, rule, and alert identifiers before inserting them into Recorded Future API paths (PSAAS-30917).
- Apply JavaScript-context escaping across alert, reputation, and intelligence widgets (PSAAS-30952, PSAAS-31036, PSAAS-31126, PSAAS-31128, PSAAS-31137, PSAAS-31170).
- Render threat-intelligence portal links only when their target is HTTPS (PSAAS-31085, PSAAS-31211).

Tracking: [PAPP-37975](https://splunk.atlassian.net/browse/PAPP-37975), parent epic ESPM-5228. VULN and FS provenance is recorded in the signed functional commits.

### Verification

- `pre-commit run --all-files`
- `python3 -m py_compile recordedfuture_connector.py`
- Targeted Django template linting and formatting
- All branch commits are signed and contain Codex attribution.

### Manual Documentation

- [x] I have verified that manual documentation has been updated where appropriate

No REST handler or authentication method changed.

### Other information

The attached patch suggestions were reviewed and adapted to the current connector implementation.

Written by Codex.